### PR TITLE
Performance: move the bailout threshold to 60fps instead of 30fps

### DIFF
--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -403,9 +403,9 @@ export class World extends EventTarget {
         this.internalStep(dt)
         this.accumulator -= dt
         substeps++
-        if (performance.now() - t0 > dt * 2 * 1000) {
+        if (performance.now() - t0 > dt * 1000) {
           // The framerate is not interactive anymore.
-          // We are at half of the target framerate.
+          // We are below the target framerate.
           // Better bail out.
           break
         }


### PR DESCRIPTION
After doing some tests, it made more sense to keep the threshold at which we skip to the next internalStep at 60fps, since it dips anyway to much lower than 60fps sometimes.

It was originally like this:
https://github.com/schteppe/cannon.js/blob/2cd242e696cd37b67a5722000abaf3edeef1d29a/src/world/World.js#L506-L509