### PR TITLE
Use the static keyword for static methods

### DIFF
--- a/src/collision/ArrayCollisionMatrix.ts
+++ b/src/collision/ArrayCollisionMatrix.ts
@@ -15,8 +15,8 @@ export class ArrayCollisionMatrix {
   /**
    * Get an element
    * @method get
-   * @param  {Body} i
-   * @param  {Body} j
+   * @param  {Body} bi
+   * @param  {Body} bj
    * @return {Number}
    */
   get(bi: Body, bj: Body): number {
@@ -33,8 +33,8 @@ export class ArrayCollisionMatrix {
   /**
    * Set an element
    * @method set
-   * @param {Body} i
-   * @param {Body} j
+   * @param {Body} bi
+   * @param {Body} bj
    * @param {boolean} value
    */
   set(bi: Body, bj: Body, value: boolean): void {

--- a/src/collision/Broadphase.ts
+++ b/src/collision/Broadphase.ts
@@ -15,8 +15,6 @@ export class Broadphase {
   useBoundingBoxes: boolean // If set to true, the broadphase uses bounding boxes for intersection test, else it uses bounding spheres.
   dirty: boolean // Set to true if the objects in the world moved.
 
-  static boundingSphereCheck: (bodyA: Body, bodyB: Body) => boolean
-
   constructor() {
     this.world = null
     this.useBoundingBoxes = false
@@ -78,6 +76,14 @@ export class Broadphase {
     }
   }
 
+  /**
+   * Check if the bounding spheres of two bodies are intersecting.
+   * @method doBoundingSphereBroadphase
+   * @param {Body} bodyA
+   * @param {Body} bodyB
+   * @param {Array} pairs1 bodyA is appended to this array if intersection
+   * @param {Array} pairs2 bodyB is appended to this array if intersection
+   */
   doBoundingSphereBroadphase(bodyA: Body, bodyB: Body, pairs1: Body[], pairs2: Body[]): void {
     const r = Broadphase_collisionPairs_r
     bodyB.position.vsub(bodyA.position, r)
@@ -112,6 +118,12 @@ export class Broadphase {
     }
   }
 
+  /**
+   * Removes duplicate pairs from the pair arrays.
+   * @method makePairsUnique
+   * @param {Array} pairs1
+   * @param {Array} pairs2
+   */
   makePairsUnique(pairs1: Body[], pairs2: Body[]): void {
     const t = Broadphase_makePairsUnique_temp
     const p1 = Broadphase_makePairsUnique_p1
@@ -151,6 +163,22 @@ export class Broadphase {
   setWorld(world: World): void {}
 
   /**
+   * Check if the bounding spheres of two bodies overlap.
+   * @static
+   * @method boundingSphereCheck
+   * @param {Body} bodyA
+   * @param {Body} bodyB
+   * @return {boolean}
+   */
+  static boundingSphereCheck(bodyA: Body, bodyB: Body): boolean {
+    const dist = new Vec3() // bsc_dist;
+    bodyA.position.vsub(bodyB.position, dist)
+    const sa = bodyA.shapes[0]
+    const sb = bodyB.shapes[0]
+    return Math.pow(sa.boundingSphereRadius + sb.boundingSphereRadius, 2) > dist.lengthSquared()
+  }
+
+  /**
    * Returns all the bodies within the AABB.
    * @method aabbQuery
    * @param  {World} world
@@ -164,44 +192,16 @@ export class Broadphase {
   }
 }
 
-/**
- * Check if the bounding spheres of two bodies are intersecting.
- * @method doBoundingSphereBroadphase
- * @param {Body} bodyA
- * @param {Body} bodyB
- * @param {Array} pairs1 bodyA is appended to this array if intersection
- * @param {Array} pairs2 bodyB is appended to this array if intersection
- */
-const // Temp objects
-  Broadphase_collisionPairs_r = new Vec3()
+// Temp objects
+const Broadphase_collisionPairs_r = new Vec3()
 
 const Broadphase_collisionPairs_normal = new Vec3()
 const Broadphase_collisionPairs_quat = new Quaternion()
 const Broadphase_collisionPairs_relpos = new Vec3()
 
-/**
- * Removes duplicate pairs from the pair arrays.
- * @method makePairsUnique
- * @param {Array} pairs1
- * @param {Array} pairs2
- */
 const Broadphase_makePairsUnique_temp: Record<string, any> = { keys: [] }
 
 const Broadphase_makePairsUnique_p1: Body[] = []
 const Broadphase_makePairsUnique_p2: Body[] = []
 
-/**
- * Check if the bounding spheres of two bodies overlap.
- * @method boundingSphereCheck
- * @param {Body} bodyA
- * @param {Body} bodyB
- * @return {boolean}
- */
 const bsc_dist = new Vec3()
-Broadphase.boundingSphereCheck = (bodyA, bodyB) => {
-  const dist = new Vec3() // bsc_dist;
-  bodyA.position.vsub(bodyB.position, dist)
-  const sa = bodyA.shapes[0]
-  const sb = bodyB.shapes[0]
-  return Math.pow(sa.boundingSphereRadius + sb.boundingSphereRadius, 2) > dist.lengthSquared()
-}

--- a/src/collision/ObjectCollisionMatrix.ts
+++ b/src/collision/ObjectCollisionMatrix.ts
@@ -14,8 +14,8 @@ export class ObjectCollisionMatrix {
 
   /**
    * @method get
-   * @param  {Body} i
-   * @param  {Body} j
+   * @param  {Body} bi
+   * @param  {Body} bj
    * @return {boolean}
    */
   get(bi: Body, bj: Body): boolean {
@@ -31,8 +31,8 @@ export class ObjectCollisionMatrix {
 
   /**
    * @method set
-   * @param  {Body} i
-   * @param  {Body} j
+   * @param  {Body} bi
+   * @param  {Body} bj
    * @param {boolean} value
    */
   set(bi: Body, bj: Body, value: boolean): void {

--- a/src/math/Vec3.ts
+++ b/src/math/Vec3.ts
@@ -31,7 +31,7 @@ export class Vec3 {
   /**
    * Vector cross product
    * @method cross
-   * @param {Vec3} v
+   * @param {Vec3} vector
    * @param {Vec3} target Optional. Target to save in.
    * @return {Vec3}
    */
@@ -76,7 +76,7 @@ export class Vec3 {
   /**
    * Vector addition
    * @method vadd
-   * @param {Vec3} v
+   * @param {Vec3} vector
    * @param {Vec3} target Optional.
    * @return {Vec3}
    */
@@ -95,7 +95,7 @@ export class Vec3 {
   /**
    * Vector subtraction
    * @method vsub
-   * @param {Vec3} v
+   * @param {Vec3} vector
    * @param {Vec3} target Optional. Target to save in.
    * @return {Vec3}
    */
@@ -271,7 +271,7 @@ export class Vec3 {
   /**
    * Calculate dot product
    * @method dot
-   * @param {Vec3} v
+   * @param {Vec3} vector
    * @return {Number}
    */
   dot(vector: Vec3): number {
@@ -361,7 +361,7 @@ export class Vec3 {
   /**
    * Do a linear interpolation between two vectors
    * @method lerp
-   * @param {Vec3} v
+   * @param {Vec3} vector
    * @param {Number} t A number between 0 and 1. 0 will make this function return u, and 1 will make it return v. Numbers in between will generate a vector in between them.
    * @param {Vec3} target
    */
@@ -377,7 +377,7 @@ export class Vec3 {
   /**
    * Check if a vector equals is almost equal to another one.
    * @method almostEquals
-   * @param {Vec3} v
+   * @param {Vec3} vector
    * @param {Number} precision
    * @return bool
    */

--- a/src/shapes/Box.ts
+++ b/src/shapes/Box.ts
@@ -15,8 +15,6 @@ export class Box extends Shape {
   halfExtents: Vec3
   convexPolyhedronRepresentation: ConvexPolyhedron // Used by the contact generator to make contacts with other convex polyhedra for example.
 
-  static calculateInertia: (halfExtents: Vec3, mass: number, target: Vec3) => void
-
   constructor(halfExtents: Vec3) {
     super({ type: Shape.types.BOX })
 
@@ -72,6 +70,13 @@ export class Box extends Shape {
   calculateLocalInertia(mass: number, target = new Vec3()): Vec3 {
     Box.calculateInertia(this.halfExtents, mass, target)
     return target
+  }
+
+  static calculateInertia(halfExtents: Vec3, mass: number, target: Vec3): void {
+    const e = halfExtents
+    target.x = (1.0 / 12.0) * mass * (2 * e.y * 2 * e.y + 2 * e.z * 2 * e.z)
+    target.y = (1.0 / 12.0) * mass * (2 * e.x * 2 * e.x + 2 * e.z * 2 * e.z)
+    target.z = (1.0 / 12.0) * mass * (2 * e.y * 2 * e.y + 2 * e.x * 2 * e.x)
   }
 
   /**
@@ -197,13 +202,6 @@ export class Box extends Shape {
     //     }
     // });
   }
-}
-
-Box.calculateInertia = (halfExtents: Vec3, mass: number, target: Vec3): void => {
-  const e = halfExtents
-  target.x = (1.0 / 12.0) * mass * (2 * e.y * 2 * e.y + 2 * e.z * 2 * e.z)
-  target.y = (1.0 / 12.0) * mass * (2 * e.x * 2 * e.x + 2 * e.z * 2 * e.z)
-  target.z = (1.0 / 12.0) * mass * (2 * e.y * 2 * e.y + 2 * e.x * 2 * e.x)
 }
 
 const worldCornerTempPos = new Vec3()

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1,19 +1,19 @@
-export function Utils() {}
-
-/**
- * Extend an options object with default values.
- * @static
- * @method defaults
- * @param  {object} options The options object. May be falsy: in this case, a new object is created and returned.
- * @param  {object} defaults An object containing default values.
- * @return {object} The modified options object.
- */
-Utils.defaults = (options: Record<string, any> = {}, defaults: Record<string, any>): Record<string, any> => {
-  for (let key in defaults) {
-    if (!(key in options)) {
-      options[key] = defaults[key]
+export class Utils {
+  /**
+   * Extend an options object with default values.
+   * @static
+   * @method defaults
+   * @param  {object} options The options object. May be falsy: in this case, a new object is created and returned.
+   * @param  {object} defaults An object containing default values.
+   * @return {object} The modified options object.
+   */
+  static defaults(options: Record<string, any> = {}, defaults: Record<string, any>): Record<string, any> {
+    for (let key in defaults) {
+      if (!(key in options)) {
+        options[key] = defaults[key]
+      }
     }
-  }
 
-  return options
+    return options
+  }
 }


### PR DESCRIPTION
For the already static methods, let's convert them fully to static methods since there is no performance difference between the two modes, I've tested this. Under the hood, class use prototypal inheritance, so memory-wise, is the same thing.

This PR contains some stuff from #47, however I didn't convert the non-static methods to static methods since there is no need to, and most likely doesn't end up in any memory savings.

https://stackoverflow.com/questions/34898166/javascript-class-static-methods-memory-consumption