### PR TITLE
Set SplitSolver parameter type as GSSolver

### DIFF
--- a/src/solver/SplitSolver.ts
+++ b/src/solver/SplitSolver.ts
@@ -2,6 +2,7 @@ import { Solver } from '../solver/Solver'
 import { Body } from '../objects/Body'
 import type { Equation } from '../equations/Equation'
 import type { World } from '../world/World'
+import { GSSolver } from './GSSolver'
 
 type SplitSolverNode = { body: Body | null; children: SplitSolverNode[]; eqs: Equation[]; visited: boolean }
 
@@ -15,11 +16,11 @@ type SplitSolverNode = { body: Body | null; children: SplitSolverNode[]; eqs: Eq
 export class SplitSolver extends Solver {
   iterations: number // The number of solver iterations determines quality of the constraints in the world. The more iterations, the more correct simulation. More iterations need more computations though. If you have a large gravity force in your world, you will need more iterations.
   tolerance: number // When tolerance is reached, the system is assumed to be converged.
-  subsolver: SplitSolver
+  subsolver: GSSolver
   nodes: SplitSolverNode[]
   nodePool: SplitSolverNode[]
 
-  constructor(subsolver: SplitSolver) {
+  constructor(subsolver: GSSolver) {
     super()
 
     this.iterations = 10


### PR DESCRIPTION
Close #57 

The SplitSolver is used like this

```js
const subsolver = new CANNON.GSSolver()
subsolver.iterations = 50
subsolver.tolerance = 0.0001

world.solver = new CANNON.SplitSolver(subsolver)
```

So it makes sense for its type to be a GSSolver.