### PR TITLE
Make WheelInfo.frictionSlip default to a lower value

### DIFF
--- a/src/objects/WheelInfo.ts
+++ b/src/objects/WheelInfo.ts
@@ -61,7 +61,7 @@ export type WheelRaycastResult = RaycastResult &
  * @param {number} [options.suspensionStiffness=100]
  * @param {number} [options.dampingCompression=10]
  * @param {number} [options.dampingRelaxation=10]
- * @param {number} [options.frictionSlip=10000]
+ * @param {number} [options.frictionSlip=10.5]
  * @param {number} [options.steering=0]
  * @param {number} [options.rotation=0]
  * @param {number} [options.deltaRotation=0]
@@ -131,7 +131,7 @@ export class WheelInfo {
       suspensionStiffness: 100,
       dampingCompression: 10,
       dampingRelaxation: 10,
-      frictionSlip: 10000,
+      frictionSlip: 10.5,
       forwardAcceleration: 1,
       sideAcceleration: 1,
       steering: 0,


### PR DESCRIPTION
As discussed in #65, align the `WheelInfo.frictionSlip` default value to the [bullet default value](https://github.com/bulletphysics/bullet3/blob/afa4fb54505fd071103b8e2e8793c38fd40f6fb6/src/BulletDynamics/Vehicle/btRaycastVehicle.h#L45).