### PR TITLE
Add Mat3, Vec3, and some Quaternion tests

### DIFF
--- a/src/math/Mat3.test.ts
+++ b/src/math/Mat3.test.ts
@@ -54,35 +54,20 @@ describe('Mat3', () => {
   test('getTrace', () => {
     const m = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
 
-    //Test for returning new vector
     const mTrace = m.getTrace()
     expect(mTrace.x).toBe(1)
     expect(mTrace.y).toBe(5)
     expect(mTrace.z).toBe(9)
-
-    //Test for changing target vector
-    const v = new Vec3()
-    m.getTrace(v)
-    expect(v.x).toBe(1)
-    expect(v.y).toBe(5)
-    expect(v.z).toBe(9)
   })
 
   test('vmult', () => {
     const v = new Vec3(2, 3, 7)
     const m = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
 
-    //Test for returning new vector
     const t = m.vmult(v)
     expect(t.x).toBe(29)
     expect(t.y).toBe(65)
     expect(t.z).toBe(101)
-
-    //Test for changing target vector
-    m.vmult(v, v)
-    expect(v.x).toBe(29)
-    expect(v.y).toBe(65)
-    expect(v.z).toBe(101)
   })
 
   test('smult', () => {
@@ -103,7 +88,6 @@ describe('Mat3', () => {
     const m1 = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
     const m2 = new Mat3([5, 2, 4, 4, 5, 1, 1, 8, 0])
 
-    //Test for returning new matrix
     const m3 = m1.mmult(m2)
     expect(m3.e(0, 0)).toBe(16)
     expect(m3.e(0, 1)).toBe(36)
@@ -114,19 +98,6 @@ describe('Mat3', () => {
     expect(m3.e(2, 0)).toBe(76)
     expect(m3.e(2, 1)).toBe(126)
     expect(m3.e(2, 2)).toBe(36)
-
-    //Test for changing target matrix
-    const m4 = new Mat3()
-    m1.mmult(m2, m4)
-    expect(m4.e(0, 0)).toBe(16)
-    expect(m4.e(0, 1)).toBe(36)
-    expect(m4.e(0, 2)).toBe(6)
-    expect(m4.e(1, 0)).toBe(46)
-    expect(m4.e(1, 1)).toBe(81)
-    expect(m4.e(1, 2)).toBe(21)
-    expect(m4.e(2, 0)).toBe(76)
-    expect(m4.e(2, 1)).toBe(126)
-    expect(m4.e(2, 2)).toBe(36)
   })
 
   test('mmult in place', () => {
@@ -150,7 +121,6 @@ describe('Mat3', () => {
     const m = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
     const v = new Vec3(2, 3, 4)
 
-    //Test for returning new matrix
     const m1 = new Mat3()
     m.scale(v, m1)
     expect(m1.e(0, 0)).toBe(2)
@@ -162,35 +132,16 @@ describe('Mat3', () => {
     expect(m1.e(2, 0)).toBe(14)
     expect(m1.e(2, 1)).toBe(24)
     expect(m1.e(2, 2)).toBe(36)
-
-    //Test for changing target matrix
-    m.scale(v, m)
-    expect(m.e(0, 0)).toBe(2)
-    expect(m.e(0, 1)).toBe(6)
-    expect(m.e(0, 2)).toBe(12)
-    expect(m.e(1, 0)).toBe(8)
-    expect(m.e(1, 1)).toBe(15)
-    expect(m.e(1, 2)).toBe(24)
-    expect(m.e(2, 0)).toBe(14)
-    expect(m.e(2, 1)).toBe(24)
-    expect(m.e(2, 2)).toBe(36)
   })
 
   test('solve', () => {
     const A = new Mat3([0, 2, 3, -4, -5, -6, 7, -8, 9])
     const b = new Vec3(0 * 10 + 2 * 11 + 3 * 12, -4 * 10 + -5 * 11 + -6 * 12, 7 * 10 + -8 * 11 + 9 * 12)
 
-    //Test for returning new vector
     const x = A.solve(b)
     expect(x.x).toBeCloseTo(10)
     expect(x.y).toBeCloseTo(11)
     expect(x.z).toBeCloseTo(12)
-
-    //Test for changing target vector
-    A.solve(b, b)
-    expect(b.x).toBeCloseTo(10)
-    expect(b.y).toBeCloseTo(11)
-    expect(b.z).toBeCloseTo(12)
 
     //Test for no solution error
     expect(() => {
@@ -260,29 +211,18 @@ describe('Mat3', () => {
 
   test('toString', () => {
     const m = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    expect(m.toString()).toBe('1,2,3,4,5,6,7,8,9,')
   })
 
   test('reverse', () => {
     const m = new Mat3([5, 2, 4, 4, 5, 1, 1, 8, 0])
 
-    //Test for returning new matrix
     const m2 = m.reverse()
     const m3 = m2.mmult(m)
     const i = new Mat3([1, 0, 0, 0, 1, 0, 0, 0, 1])
     for (let c = 0; c < 3; c++) {
       for (let r = 0; r < 3; r++) {
         expect(m3.e(r, c)).toBeCloseTo(i.e(r, c))
-      }
-    }
-
-    //Test for changing target matrix
-    const n = new Mat3([5, 2, 4, 4, 5, 1, 1, 8, 0])
-    const n2 = new Mat3([5, 2, 4, 4, 5, 1, 1, 8, 0])
-    n.reverse(n)
-    const n3 = n2.mmult(n)
-    for (let c = 0; c < 3; c++) {
-      for (let r = 0; r < 3; r++) {
-        expect(n3.e(r, c)).toBeCloseTo(i.e(r, c))
       }
     }
 
@@ -323,7 +263,6 @@ describe('Mat3', () => {
   test('transpose', () => {
     const M = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
 
-    //Test for returning new matrix
     const Mt = M.transpose()
     expect(Mt.e(0, 0)).toBe(1)
     expect(Mt.e(0, 1)).toBe(4)
@@ -334,19 +273,6 @@ describe('Mat3', () => {
     expect(Mt.e(2, 0)).toBe(3)
     expect(Mt.e(2, 1)).toBe(6)
     expect(Mt.e(2, 2)).toBe(9)
-
-    //Test for changing target matrix
-    const T = new Mat3()
-    M.transpose(T)
-    expect(T.e(0, 0)).toBe(1)
-    expect(T.e(0, 1)).toBe(4)
-    expect(T.e(0, 2)).toBe(7)
-    expect(T.e(1, 0)).toBe(2)
-    expect(T.e(1, 1)).toBe(5)
-    expect(T.e(1, 2)).toBe(8)
-    expect(T.e(2, 0)).toBe(3)
-    expect(T.e(2, 1)).toBe(6)
-    expect(T.e(2, 2)).toBe(9)
 
     //Ensure input matrix unchanged
     expect(M.e(0, 0)).toBe(1)

--- a/src/math/Mat3.test.ts
+++ b/src/math/Mat3.test.ts
@@ -1,0 +1,377 @@
+import { Mat3 } from './Mat3'
+import { Vec3 } from './Vec3'
+import { Quaternion } from './Quaternion'
+
+describe('Mat3', () => {
+  test('construct', () => {
+    const m = new Mat3()
+    for (let c = 0; c < 3; c++) {
+      for (let r = 0; r < 3; r++) {
+        expect(m.e(r, c)).toBe(0)
+      }
+    }
+  })
+
+  test('identity', () => {
+    const m = new Mat3()
+    m.identity()
+    expect(m.e(0, 0)).toBe(1)
+    expect(m.e(0, 1)).toBe(0)
+    expect(m.e(0, 2)).toBe(0)
+    expect(m.e(1, 0)).toBe(0)
+    expect(m.e(1, 1)).toBe(1)
+    expect(m.e(1, 2)).toBe(0)
+    expect(m.e(2, 0)).toBe(0)
+    expect(m.e(2, 1)).toBe(0)
+    expect(m.e(2, 2)).toBe(1)
+  })
+
+  test('setZero', () => {
+    const m = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    m.setZero()
+    for (let c = 0; c < 3; c++) {
+      for (let r = 0; r < 3; r++) {
+        expect(m.e(r, c)).toBe(0)
+      }
+    }
+  })
+
+  test('setTrace', () => {
+    const m = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    m.setTrace(new Vec3(10, 11, 12))
+
+    expect(m.e(0, 0)).toBe(10)
+    expect(m.e(0, 1)).toBe(2)
+    expect(m.e(0, 2)).toBe(3)
+    expect(m.e(1, 0)).toBe(4)
+    expect(m.e(1, 1)).toBe(11)
+    expect(m.e(1, 2)).toBe(6)
+    expect(m.e(2, 0)).toBe(7)
+    expect(m.e(2, 1)).toBe(8)
+    expect(m.e(2, 2)).toBe(12)
+  })
+
+  test('getTrace', () => {
+    const m = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+    //Test for returning new vector
+    const mTrace = m.getTrace()
+    expect(mTrace.x).toBe(1)
+    expect(mTrace.y).toBe(5)
+    expect(mTrace.z).toBe(9)
+
+    //Test for changing target vector
+    const v = new Vec3()
+    m.getTrace(v)
+    expect(v.x).toBe(1)
+    expect(v.y).toBe(5)
+    expect(v.z).toBe(9)
+  })
+
+  test('vmult', () => {
+    const v = new Vec3(2, 3, 7)
+    const m = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+    //Test for returning new vector
+    const t = m.vmult(v)
+    expect(t.x).toBe(29)
+    expect(t.y).toBe(65)
+    expect(t.z).toBe(101)
+
+    //Test for changing target vector
+    m.vmult(v, v)
+    expect(v.x).toBe(29)
+    expect(v.y).toBe(65)
+    expect(v.z).toBe(101)
+  })
+
+  test('smult', () => {
+    const m = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    m.smult(10)
+    expect(m.e(0, 0)).toBe(10)
+    expect(m.e(0, 1)).toBe(20)
+    expect(m.e(0, 2)).toBe(30)
+    expect(m.e(1, 0)).toBe(40)
+    expect(m.e(1, 1)).toBe(50)
+    expect(m.e(1, 2)).toBe(60)
+    expect(m.e(2, 0)).toBe(70)
+    expect(m.e(2, 1)).toBe(80)
+    expect(m.e(2, 2)).toBe(90)
+  })
+
+  test('mmult', () => {
+    const m1 = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    const m2 = new Mat3([5, 2, 4, 4, 5, 1, 1, 8, 0])
+
+    //Test for returning new matrix
+    const m3 = m1.mmult(m2)
+    expect(m3.e(0, 0)).toBe(16)
+    expect(m3.e(0, 1)).toBe(36)
+    expect(m3.e(0, 2)).toBe(6)
+    expect(m3.e(1, 0)).toBe(46)
+    expect(m3.e(1, 1)).toBe(81)
+    expect(m3.e(1, 2)).toBe(21)
+    expect(m3.e(2, 0)).toBe(76)
+    expect(m3.e(2, 1)).toBe(126)
+    expect(m3.e(2, 2)).toBe(36)
+
+    //Test for changing target matrix
+    const m4 = new Mat3()
+    m1.mmult(m2, m4)
+    expect(m4.e(0, 0)).toBe(16)
+    expect(m4.e(0, 1)).toBe(36)
+    expect(m4.e(0, 2)).toBe(6)
+    expect(m4.e(1, 0)).toBe(46)
+    expect(m4.e(1, 1)).toBe(81)
+    expect(m4.e(1, 2)).toBe(21)
+    expect(m4.e(2, 0)).toBe(76)
+    expect(m4.e(2, 1)).toBe(126)
+    expect(m4.e(2, 2)).toBe(36)
+  })
+
+  test('mmult in place', () => {
+    const m1 = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    const m2 = new Mat3([5, 2, 4, 4, 5, 1, 1, 8, 0])
+
+    //Test for changing input matrix
+    m1.mmult(m2, m1)
+    expect(m1.e(0, 0)).toBe(16)
+    expect(m1.e(0, 1)).toBe(36)
+    expect(m1.e(0, 2)).toBe(6)
+    expect(m1.e(1, 0)).toBe(46)
+    expect(m1.e(1, 1)).toBe(81)
+    expect(m1.e(1, 2)).toBe(21)
+    expect(m1.e(2, 0)).toBe(76)
+    expect(m1.e(2, 1)).toBe(126)
+    expect(m1.e(2, 2)).toBe(36)
+  })
+
+  test('scale', () => {
+    const m = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    const v = new Vec3(2, 3, 4)
+
+    //Test for returning new matrix
+    const m1 = new Mat3()
+    m.scale(v, m1)
+    expect(m1.e(0, 0)).toBe(2)
+    expect(m1.e(0, 1)).toBe(6)
+    expect(m1.e(0, 2)).toBe(12)
+    expect(m1.e(1, 0)).toBe(8)
+    expect(m1.e(1, 1)).toBe(15)
+    expect(m1.e(1, 2)).toBe(24)
+    expect(m1.e(2, 0)).toBe(14)
+    expect(m1.e(2, 1)).toBe(24)
+    expect(m1.e(2, 2)).toBe(36)
+
+    //Test for changing target matrix
+    m.scale(v, m)
+    expect(m.e(0, 0)).toBe(2)
+    expect(m.e(0, 1)).toBe(6)
+    expect(m.e(0, 2)).toBe(12)
+    expect(m.e(1, 0)).toBe(8)
+    expect(m.e(1, 1)).toBe(15)
+    expect(m.e(1, 2)).toBe(24)
+    expect(m.e(2, 0)).toBe(14)
+    expect(m.e(2, 1)).toBe(24)
+    expect(m.e(2, 2)).toBe(36)
+  })
+
+  test('solve', () => {
+    const A = new Mat3([0, 2, 3, -4, -5, -6, 7, -8, 9])
+    const b = new Vec3(0 * 10 + 2 * 11 + 3 * 12, -4 * 10 + -5 * 11 + -6 * 12, 7 * 10 + -8 * 11 + 9 * 12)
+
+    //Test for returning new vector
+    const x = A.solve(b)
+    expect(x.x).toBeCloseTo(10)
+    expect(x.y).toBeCloseTo(11)
+    expect(x.z).toBeCloseTo(12)
+
+    //Test for changing target vector
+    A.solve(b, b)
+    expect(b.x).toBeCloseTo(10)
+    expect(b.y).toBeCloseTo(11)
+    expect(b.z).toBeCloseTo(12)
+
+    //Test for no solution error
+    expect(() => {
+      const C = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
+      const d = new Vec3(1 * 10 + 2 * 11 + 3 * 12, 4 * 10 + 5 * 11 + 6 * 12, 7 * 10 + 8 * 11 + 9 * 12)
+      C.solve(d, d)
+    }).toThrow()
+  })
+
+  test('e', () => {
+    //Getting
+    const m = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    expect(m.e(0, 0)).toBe(1)
+    expect(m.e(0, 1)).toBe(2)
+    expect(m.e(0, 2)).toBe(3)
+    expect(m.e(1, 0)).toBe(4)
+    expect(m.e(1, 1)).toBe(5)
+    expect(m.e(1, 2)).toBe(6)
+    expect(m.e(2, 0)).toBe(7)
+    expect(m.e(2, 1)).toBe(8)
+    expect(m.e(2, 2)).toBe(9)
+
+    //Setting
+    m.e(0, 0, -1)
+    m.e(0, 1, -2)
+    m.e(0, 2, -3)
+    m.e(1, 0, -4)
+    m.e(1, 1, -5)
+    m.e(1, 2, -6)
+    m.e(2, 0, -7)
+    m.e(2, 1, -8)
+    m.e(2, 2, -9)
+    expect(m.e(0, 0)).toBe(-1)
+    expect(m.e(0, 1)).toBe(-2)
+    expect(m.e(0, 2)).toBe(-3)
+    expect(m.e(1, 0)).toBe(-4)
+    expect(m.e(1, 1)).toBe(-5)
+    expect(m.e(1, 2)).toBe(-6)
+    expect(m.e(2, 0)).toBe(-7)
+    expect(m.e(2, 1)).toBe(-8)
+    expect(m.e(2, 2)).toBe(-9)
+  })
+
+  test('copy', () => {
+    const m = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    const u = new Mat3()
+    expect(u.copy(m)).toBe(u)
+    m.e(0, 0, -1)
+    m.e(0, 1, -2)
+    m.e(0, 2, -3)
+    m.e(1, 0, -4)
+    m.e(1, 1, -5)
+    m.e(1, 2, -6)
+    m.e(2, 0, -7)
+    m.e(2, 1, -8)
+    m.e(2, 2, -9)
+    expect(u.e(0, 0)).toBe(1)
+    expect(u.e(0, 1)).toBe(2)
+    expect(u.e(0, 2)).toBe(3)
+    expect(u.e(1, 0)).toBe(4)
+    expect(u.e(1, 1)).toBe(5)
+    expect(u.e(1, 2)).toBe(6)
+    expect(u.e(2, 0)).toBe(7)
+    expect(u.e(2, 1)).toBe(8)
+    expect(u.e(2, 2)).toBe(9)
+  })
+
+  test('toString', () => {
+    const m = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
+  })
+
+  test('reverse', () => {
+    const m = new Mat3([5, 2, 4, 4, 5, 1, 1, 8, 0])
+
+    //Test for returning new matrix
+    const m2 = m.reverse()
+    const m3 = m2.mmult(m)
+    const i = new Mat3([1, 0, 0, 0, 1, 0, 0, 0, 1])
+    for (let c = 0; c < 3; c++) {
+      for (let r = 0; r < 3; r++) {
+        expect(m3.e(r, c)).toBeCloseTo(i.e(r, c))
+      }
+    }
+
+    //Test for changing target matrix
+    const n = new Mat3([5, 2, 4, 4, 5, 1, 1, 8, 0])
+    const n2 = new Mat3([5, 2, 4, 4, 5, 1, 1, 8, 0])
+    n.reverse(n)
+    const n3 = n2.mmult(n)
+    for (let c = 0; c < 3; c++) {
+      for (let r = 0; r < 3; r++) {
+        expect(n3.e(r, c)).toBeCloseTo(i.e(r, c))
+      }
+    }
+
+    //Test different pivot
+    const A = new Mat3([0, 2, 3, -4, -5, -6, 7, -8, 9])
+    const b = new Vec3(0 * 10 + 2 * 11 + 3 * 12, -4 * 10 + -5 * 11 + -6 * 12, 7 * 10 + -8 * 11 + 9 * 12)
+    const inA = A.reverse()
+    const x = inA.vmult(b)
+    expect(x.x).toBeCloseTo(10)
+    expect(x.y).toBeCloseTo(11)
+    expect(x.z).toBeCloseTo(12)
+
+    //Test for no solution error
+    expect(() => {
+      const o = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
+      o.reverse(o)
+    }).toThrow()
+  })
+
+  test('setRotationFromQuaternion', () => {
+    const M = new Mat3()
+    const q = new Quaternion()
+    const original = new Vec3(1, 2, 3)
+
+    //Test zero rotation
+    M.setRotationFromQuaternion(q)
+    const v = M.vmult(original)
+    expect(v.almostEquals(original))
+
+    //Test rotation along x axis
+    q.setFromEuler(0.222, 0.123, 1.234)
+    M.setRotationFromQuaternion(q)
+    const Mv = M.vmult(original)
+    const qv = q.vmult(original)
+    expect(Mv.almostEquals(qv))
+  })
+
+  test('transpose', () => {
+    const M = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+    //Test for returning new matrix
+    const Mt = M.transpose()
+    expect(Mt.e(0, 0)).toBe(1)
+    expect(Mt.e(0, 1)).toBe(4)
+    expect(Mt.e(0, 2)).toBe(7)
+    expect(Mt.e(1, 0)).toBe(2)
+    expect(Mt.e(1, 1)).toBe(5)
+    expect(Mt.e(1, 2)).toBe(8)
+    expect(Mt.e(2, 0)).toBe(3)
+    expect(Mt.e(2, 1)).toBe(6)
+    expect(Mt.e(2, 2)).toBe(9)
+
+    //Test for changing target matrix
+    const T = new Mat3()
+    M.transpose(T)
+    expect(T.e(0, 0)).toBe(1)
+    expect(T.e(0, 1)).toBe(4)
+    expect(T.e(0, 2)).toBe(7)
+    expect(T.e(1, 0)).toBe(2)
+    expect(T.e(1, 1)).toBe(5)
+    expect(T.e(1, 2)).toBe(8)
+    expect(T.e(2, 0)).toBe(3)
+    expect(T.e(2, 1)).toBe(6)
+    expect(T.e(2, 2)).toBe(9)
+
+    //Ensure input matrix unchanged
+    expect(M.e(0, 0)).toBe(1)
+    expect(M.e(0, 1)).toBe(2)
+    expect(M.e(0, 2)).toBe(3)
+    expect(M.e(1, 0)).toBe(4)
+    expect(M.e(1, 1)).toBe(5)
+    expect(M.e(1, 2)).toBe(6)
+    expect(M.e(2, 0)).toBe(7)
+    expect(M.e(2, 1)).toBe(8)
+    expect(M.e(2, 2)).toBe(9)
+  })
+
+  test('transpose in place', () => {
+    //Test for changing input matrix
+    const M = new Mat3([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    M.transpose(M)
+    expect(M.e(0, 0)).toBe(1)
+    expect(M.e(0, 1)).toBe(4)
+    expect(M.e(0, 2)).toBe(7)
+    expect(M.e(1, 0)).toBe(2)
+    expect(M.e(1, 1)).toBe(5)
+    expect(M.e(1, 2)).toBe(8)
+    expect(M.e(2, 0)).toBe(3)
+    expect(M.e(2, 1)).toBe(6)
+    expect(M.e(2, 2)).toBe(9)
+  })
+})

--- a/src/math/Mat3.ts
+++ b/src/math/Mat3.ts
@@ -115,15 +115,17 @@ export class Mat3 {
    */
   mmult(matrix: Mat3, target = new Mat3()): Mat3 {
     const { elements } = matrix
+    const result = Mat3_mmult_result
     for (let i = 0; i < 3; i++) {
       for (let j = 0; j < 3; j++) {
         let sum = 0.0
         for (let k = 0; k < 3; k++) {
           sum += elements[i + k * 3] * this.elements[k + j * 3]
         }
-        target.elements[i + j * 3] = sum
+        result.elements[i + j * 3] = sum
       }
     }
+    target.copy(result)
     return target
   }
 
@@ -424,7 +426,7 @@ export class Mat3 {
    * @return {Mat3} The target Mat3, or a new Mat3 if target was omitted.
    */
   transpose(target = new Mat3()): Mat3 {
-    const Mt = target.elements
+    const Mt = Mat3_transpose_result.elements
     const M = this.elements
 
     for (let i = 0; i !== 3; i++) {
@@ -432,7 +434,9 @@ export class Mat3 {
         Mt[3 * i + j] = M[3 * j + i]
       }
     }
-
+    target.copy(Mat3_transpose_result)
     return target
   }
 }
+const Mat3_transpose_result = new Mat3()
+const Mat3_mmult_result = new Mat3()

--- a/src/math/Mat3.ts
+++ b/src/math/Mat3.ts
@@ -234,14 +234,13 @@ export class Mat3 {
    * @param {Number} value Optional. If provided, the matrix element will be set to this value.
    * @return {Number}
    */
-  e(row: number, column: number): number
-  e(row: number, column: number, value: number): void
-  e(row: number, column: number, value?: number): number | void {
+  e(row: number, column: number, value?: number): number {
     if (value === undefined) {
       return this.elements[column + 3 * row]
     } else {
       // Set value
       this.elements[column + 3 * row] = value
+      return value
     }
   }
 

--- a/src/math/Mat3.ts
+++ b/src/math/Mat3.ts
@@ -236,13 +236,14 @@ export class Mat3 {
    * @param {Number} value Optional. If provided, the matrix element will be set to this value.
    * @return {Number}
    */
-  e(row: number, column: number, value?: number): number {
+  e(row: number, column: number): number
+  e(row: number, column: number, value: number): void
+  e(row: number, column: number, value?: number): number | void {
     if (value === undefined) {
       return this.elements[column + 3 * row]
     } else {
       // Set value
       this.elements[column + 3 * row] = value
-      return value
     }
   }
 

--- a/src/math/Mat3.ts
+++ b/src/math/Mat3.ts
@@ -70,11 +70,12 @@ export class Mat3 {
    * @method getTrace
    * @return {Vec3}
    */
-  getTrace(target = new Vec3()): void {
+  getTrace(target = new Vec3()): Vec3 {
     const e = this.elements
     target.x = e[0]
     target.y = e[4]
     target.z = e[8]
+    return target
   }
 
   /**

--- a/src/math/Mat3.ts
+++ b/src/math/Mat3.ts
@@ -114,18 +114,42 @@ export class Mat3 {
    * @return {Mat3} The result.
    */
   mmult(matrix: Mat3, target = new Mat3()): Mat3 {
-    const { elements } = matrix
-    const result = Mat3_mmult_result
-    for (let i = 0; i < 3; i++) {
-      for (let j = 0; j < 3; j++) {
-        let sum = 0.0
-        for (let k = 0; k < 3; k++) {
-          sum += elements[i + k * 3] * this.elements[k + j * 3]
-        }
-        result.elements[i + j * 3] = sum
-      }
-    }
-    target.copy(result)
+    const A = this.elements
+    const B = matrix.elements
+    const T = target.elements
+
+    const a11 = A[0],
+      a12 = A[1],
+      a13 = A[2],
+      a21 = A[3],
+      a22 = A[4],
+      a23 = A[5],
+      a31 = A[6],
+      a32 = A[7],
+      a33 = A[8]
+
+    const b11 = B[0],
+      b12 = B[1],
+      b13 = B[2],
+      b21 = B[3],
+      b22 = B[4],
+      b23 = B[5],
+      b31 = B[6],
+      b32 = B[7],
+      b33 = B[8]
+
+    T[0] = a11 * b11 + a12 * b21 + a13 * b31
+    T[1] = a11 * b12 + a12 * b22 + a13 * b32
+    T[2] = a11 * b13 + a12 * b23 + a13 * b33
+
+    T[3] = a21 * b11 + a22 * b21 + a23 * b31
+    T[4] = a21 * b12 + a22 * b22 + a23 * b32
+    T[5] = a21 * b13 + a22 * b23 + a23 * b33
+
+    T[6] = a31 * b11 + a32 * b21 + a33 * b31
+    T[7] = a31 * b12 + a32 * b22 + a33 * b32
+    T[8] = a31 * b13 + a32 * b23 + a33 * b33
+
     return target
   }
 
@@ -427,17 +451,27 @@ export class Mat3 {
    * @return {Mat3} The target Mat3, or a new Mat3 if target was omitted.
    */
   transpose(target = new Mat3()): Mat3 {
-    const Mt = Mat3_transpose_result.elements
     const M = this.elements
+    const T = target.elements
+    let tmp
 
-    for (let i = 0; i !== 3; i++) {
-      for (let j = 0; j !== 3; j++) {
-        Mt[3 * i + j] = M[3 * j + i]
-      }
-    }
-    target.copy(Mat3_transpose_result)
+    //Set diagonals
+    T[0] = M[0]
+    T[4] = M[4]
+    T[8] = M[8]
+
+    tmp = M[1]
+    T[1] = M[3]
+    T[3] = tmp
+
+    tmp = M[2]
+    T[2] = M[6]
+    T[6] = tmp
+
+    tmp = M[5]
+    T[5] = M[7]
+    T[7] = tmp
+
     return target
   }
 }
-const Mat3_transpose_result = new Mat3()
-const Mat3_mmult_result = new Mat3()

--- a/src/math/Quaternion.test.ts
+++ b/src/math/Quaternion.test.ts
@@ -53,6 +53,9 @@ describe('Quaternion', () => {
 
     q.setFromVectors(new Vec3(0, 0, 1), new Vec3(0, 0, -1))
     expect(q.vmult(new Vec3(0, 0, 1)).almostEquals(new Vec3(0, 0, -1))).toBe(true)
+
+    q.setFromVectors(new Vec3(1, 2, 3), new Vec3(2, 1, 3))
+    expect(q.vmult(new Vec3(1, 2, 3)).almostEquals(new Vec3(2, 1, 3))).toBe(true)
   })
 
   test('slerp', () => {
@@ -65,5 +68,49 @@ describe('Quaternion', () => {
     qb.setFromAxisAngle(new Vec3(0, 0, 1), -Math.PI / 4)
     qa.slerp(qb, 0.5, qb)
     expect(qb).toStrictEqual(new Quaternion())
+  })
+
+  test('set', () => {
+    const q = new Quaternion(1, 2, 3, 4)
+    q.set(5, 6, 7, 8)
+    expect(q.x).toBe(5)
+    expect(q.y).toBe(6)
+    expect(q.z).toBe(7)
+    expect(q.w).toBe(8)
+  })
+
+  test('toString', () => {
+    const q = new Quaternion(1, 2, 3, 4)
+    expect(q.toString()).toBe('1,2,3,4')
+  })
+
+  test('toArray', () => {
+    const q = new Quaternion(1, 2, 3, 4)
+    const qa = q.toArray()
+    expect(qa[0]).toBe(1)
+    expect(qa[1]).toBe(2)
+    expect(qa[2]).toBe(3)
+    expect(qa[3]).toBe(4)
+  })
+
+  test('copy', () => {
+    const q = new Quaternion(1, 2, 3, 4)
+    const qc = new Quaternion()
+    qc.copy(q)
+    q.set(4, 5, 6, 7)
+    expect(qc.x).toBe(1)
+    expect(qc.y).toBe(2)
+    expect(qc.z).toBe(3)
+    expect(qc.w).toBe(4)
+  })
+
+  test('clone', () => {
+    const q = new Quaternion(1, 2, 3, 4)
+    const qc = q.clone()
+    q.set(4, 5, 6, 7)
+    expect(qc.x).toBe(1)
+    expect(qc.y).toBe(2)
+    expect(qc.z).toBe(3)
+    expect(qc.w).toBe(4)
   })
 })

--- a/src/math/Vec3.test.ts
+++ b/src/math/Vec3.test.ts
@@ -12,17 +12,10 @@ describe('Vec3', () => {
     const v = new Vec3(1, 2, 3)
     const u = new Vec3(4, 5, 6)
 
-    //Test for returning new vector
     const v_x_u = v.cross(u)
     expect(v_x_u.x).toBe(-3)
     expect(v_x_u.y).toBe(6)
     expect(v_x_u.z).toBe(-3)
-
-    //Test for changing target vector
-    v.cross(u, v)
-    expect(v.x).toBe(-3)
-    expect(v.y).toBe(6)
-    expect(v.z).toBe(-3)
   })
 
   test('set', () => {
@@ -46,34 +39,20 @@ describe('Vec3', () => {
     const v = new Vec3(1, 2, 3)
     const u = new Vec3(4, 5, 6)
 
-    //Test for returning new vector
     const w = v.vadd(u)
     expect(w.x).toBe(5)
     expect(w.y).toBe(7)
     expect(w.z).toBe(9)
-
-    //Test for changing target vector
-    v.vadd(u, v)
-    expect(v.x).toBe(5)
-    expect(v.y).toBe(7)
-    expect(v.z).toBe(9)
   })
 
   test('vsub', () => {
     const v = new Vec3(1, 2, 3)
     const u = new Vec3(4, 6, 8)
 
-    //Test for returning new vector
     const w = v.vsub(u)
     expect(w.x).toBe(-3)
     expect(w.y).toBe(-4)
     expect(w.z).toBe(-5)
-
-    //Test for changing target vector
-    v.vsub(u, v)
-    expect(v.x).toBe(-3)
-    expect(v.y).toBe(-4)
-    expect(v.z).toBe(-5)
   })
 
   test('normalize', () => {
@@ -99,12 +78,6 @@ describe('Vec3', () => {
     expect(unit_v.x).toBeCloseTo(2 / 7)
     expect(unit_v.y).toBeCloseTo(3 / 7)
     expect(unit_v.z).toBeCloseTo(6 / 7)
-
-    //Test for changing target vector
-    v.unit(v)
-    expect(v.x).toBeCloseTo(2 / 7)
-    expect(v.y).toBeCloseTo(3 / 7)
-    expect(v.z).toBeCloseTo(6 / 7)
   })
 
   test('unit_0', () => {
@@ -142,51 +115,30 @@ describe('Vec3', () => {
   test('scale', () => {
     const v = new Vec3(1, 2, 3)
 
-    //Test for returning new vector
     const v2 = v.scale(2)
     expect(v2.x).toBe(2)
     expect(v2.y).toBe(4)
     expect(v2.z).toBe(6)
-
-    //Test for changing target vector
-    v.scale(2, v)
-    expect(v.x).toBe(2)
-    expect(v.y).toBe(4)
-    expect(v.z).toBe(6)
   })
 
   test('vmul', () => {
     const v = new Vec3(1, 2, 3)
     const u = new Vec3(4, 5, 6)
 
-    //Test for returning new vector
     const vu = v.vmul(u)
     expect(vu.x).toBe(4)
     expect(vu.y).toBe(10)
     expect(vu.z).toBe(18)
-
-    //Test for changing target vector
-    v.vmul(u, v)
-    expect(v.x).toBe(4)
-    expect(v.y).toBe(10)
-    expect(v.z).toBe(18)
   })
 
   test('addScaledVector', () => {
     const v = new Vec3(1, 2, 3)
     const u = new Vec3(4, 5, 6)
 
-    //Test for returning new vector
     const v3u = v.addScaledVector(3, u)
     expect(v3u.x).toBe(13)
     expect(v3u.y).toBe(17)
     expect(v3u.z).toBe(21)
-
-    //Test for changing target vector
-    v.addScaledVector(3, u, v)
-    expect(v.x).toBe(13)
-    expect(v.y).toBe(17)
-    expect(v.z).toBe(21)
   })
 
   test('dot', () => {
@@ -214,17 +166,10 @@ describe('Vec3', () => {
   test('negate', () => {
     const v = new Vec3(1, 2, 3)
 
-    //Test for returning new vector
     const neg_v = v.negate()
     expect(neg_v.x).toBe(-1)
     expect(neg_v.y).toBe(-2)
     expect(neg_v.z).toBe(-3)
-
-    //Test for changing target vector
-    v.negate(v)
-    expect(v.x).toBe(-1)
-    expect(v.y).toBe(-2)
-    expect(v.z).toBe(-3)
   })
 
   test('tangents', () => {
@@ -263,7 +208,6 @@ describe('Vec3', () => {
     const v = new Vec3(1, 2, 3)
     const u = new Vec3(5, 6, 7)
 
-    //lerp does not implement new target vector
     const vlerpu = new Vec3()
     v.lerp(u, 0.5, vlerpu)
     expect(vlerpu.x).toBeCloseTo(3)

--- a/src/math/Vec3.test.ts
+++ b/src/math/Vec3.test.ts
@@ -1,0 +1,301 @@
+import { Vec3 } from './Vec3'
+
+describe('Vec3', () => {
+  test('construct', () => {
+    const v = new Vec3(1, 2, 3)
+    expect(v.x).toBe(1)
+    expect(v.y).toBe(2)
+    expect(v.z).toBe(3)
+  })
+
+  test('cross', () => {
+    const v = new Vec3(1, 2, 3)
+    const u = new Vec3(4, 5, 6)
+
+    //Test for returning new vector
+    const v_x_u = v.cross(u)
+    expect(v_x_u.x).toBe(-3)
+    expect(v_x_u.y).toBe(6)
+    expect(v_x_u.z).toBe(-3)
+
+    //Test for changing target vector
+    v.cross(u, v)
+    expect(v.x).toBe(-3)
+    expect(v.y).toBe(6)
+    expect(v.z).toBe(-3)
+  })
+
+  test('set', () => {
+    const v = new Vec3(1, 2, 3)
+    v.set(4, 5, 6)
+
+    expect(v.x).toBe(4)
+    expect(v.y).toBe(5)
+    expect(v.z).toBe(6)
+  })
+
+  test('setZero', () => {
+    const v = new Vec3(1, 2, 3)
+    v.setZero()
+    expect(v.x).toBe(0)
+    expect(v.y).toBe(0)
+    expect(v.z).toBe(0)
+  })
+
+  test('vadd', () => {
+    const v = new Vec3(1, 2, 3)
+    const u = new Vec3(4, 5, 6)
+
+    //Test for returning new vector
+    const w = v.vadd(u)
+    expect(w.x).toBe(5)
+    expect(w.y).toBe(7)
+    expect(w.z).toBe(9)
+
+    //Test for changing target vector
+    v.vadd(u, v)
+    expect(v.x).toBe(5)
+    expect(v.y).toBe(7)
+    expect(v.z).toBe(9)
+  })
+
+  test('vsub', () => {
+    const v = new Vec3(1, 2, 3)
+    const u = new Vec3(4, 6, 8)
+
+    //Test for returning new vector
+    const w = v.vsub(u)
+    expect(w.x).toBe(-3)
+    expect(w.y).toBe(-4)
+    expect(w.z).toBe(-5)
+
+    //Test for changing target vector
+    v.vsub(u, v)
+    expect(v.x).toBe(-3)
+    expect(v.y).toBe(-4)
+    expect(v.z).toBe(-5)
+  })
+
+  test('normalize', () => {
+    const v = new Vec3(2, 3, 6)
+    const norm = v.normalize()
+    expect(norm).toBe(7)
+    expect(v.x).toBeCloseTo(2 / 7)
+    expect(v.y).toBeCloseTo(3 / 7)
+    expect(v.z).toBeCloseTo(6 / 7)
+  })
+
+  test('normalize_0', () => {
+    const v = new Vec3(0, 0, 0)
+    const something = v.normalize()
+    expect(something).toBeDefined()
+  })
+
+  test('unit', () => {
+    const v = new Vec3(2, 3, 6)
+
+    //Test for returning new vector
+    const unit_v = v.unit()
+    expect(unit_v.x).toBeCloseTo(2 / 7)
+    expect(unit_v.y).toBeCloseTo(3 / 7)
+    expect(unit_v.z).toBeCloseTo(6 / 7)
+
+    //Test for changing target vector
+    v.unit(v)
+    expect(v.x).toBeCloseTo(2 / 7)
+    expect(v.y).toBeCloseTo(3 / 7)
+    expect(v.z).toBeCloseTo(6 / 7)
+  })
+
+  test('unit_0', () => {
+    const v = new Vec3(0, 0, 0)
+    const something = v.unit()
+    expect(something).toBeDefined()
+  })
+
+  test('length', () => {
+    const v = new Vec3(2, 3, 6)
+    const v_len = v.length()
+    expect(v_len).toBeCloseTo(7)
+  })
+
+  test('lengthSquared', () => {
+    const v = new Vec3(2, 3, 6)
+    const v_len_2 = v.lengthSquared()
+    expect(v_len_2).toBe(7 * 7)
+  })
+
+  test('distanceTo', () => {
+    const v = new Vec3(1, 2, 3)
+    const u = new Vec3(3, 5, 9)
+    expect(v.distanceTo(u)).toBeCloseTo(7)
+    expect(u.distanceTo(v)).toBeCloseTo(7)
+  })
+
+  test('distanceSquared', () => {
+    const v = new Vec3(1, 2, 3)
+    const u = new Vec3(3, 5, 9)
+    expect(v.distanceSquared(u)).toBe(7 * 7)
+    expect(u.distanceSquared(v)).toBe(7 * 7)
+  })
+
+  test('scale', () => {
+    const v = new Vec3(1, 2, 3)
+
+    //Test for returning new vector
+    const v2 = v.scale(2)
+    expect(v2.x).toBe(2)
+    expect(v2.y).toBe(4)
+    expect(v2.z).toBe(6)
+
+    //Test for changing target vector
+    v.scale(2, v)
+    expect(v.x).toBe(2)
+    expect(v.y).toBe(4)
+    expect(v.z).toBe(6)
+  })
+
+  test('vmul', () => {
+    const v = new Vec3(1, 2, 3)
+    const u = new Vec3(4, 5, 6)
+
+    //Test for returning new vector
+    const vu = v.vmul(u)
+    expect(vu.x).toBe(4)
+    expect(vu.y).toBe(10)
+    expect(vu.z).toBe(18)
+
+    //Test for changing target vector
+    v.vmul(u, v)
+    expect(v.x).toBe(4)
+    expect(v.y).toBe(10)
+    expect(v.z).toBe(18)
+  })
+
+  test('addScaledVector', () => {
+    const v = new Vec3(1, 2, 3)
+    const u = new Vec3(4, 5, 6)
+
+    //Test for returning new vector
+    const v3u = v.addScaledVector(3, u)
+    expect(v3u.x).toBe(13)
+    expect(v3u.y).toBe(17)
+    expect(v3u.z).toBe(21)
+
+    //Test for changing target vector
+    v.addScaledVector(3, u, v)
+    expect(v.x).toBe(13)
+    expect(v.y).toBe(17)
+    expect(v.z).toBe(21)
+  })
+
+  test('dot', () => {
+    let v = new Vec3(1, 2, 3)
+    let u = new Vec3(4, 5, 6)
+    let dot = v.dot(u)
+
+    expect(dot).toBe(4 + 10 + 18)
+
+    v = new Vec3(3, 2, 1)
+    u = new Vec3(4, 5, 6)
+    dot = v.dot(u)
+
+    expect(dot).toBe(12 + 10 + 6)
+  })
+
+  test('isZero', () => {
+    const v = new Vec3(1, 2, 3)
+    expect(v.isZero()).toBe(false)
+
+    const u = new Vec3(0, 0, 0)
+    expect(u.isZero()).toBe(true)
+  })
+
+  test('negate', () => {
+    const v = new Vec3(1, 2, 3)
+
+    //Test for returning new vector
+    const neg_v = v.negate()
+    expect(neg_v.x).toBe(-1)
+    expect(neg_v.y).toBe(-2)
+    expect(neg_v.z).toBe(-3)
+
+    //Test for changing target vector
+    v.negate(v)
+    expect(v.x).toBe(-1)
+    expect(v.y).toBe(-2)
+    expect(v.z).toBe(-3)
+  })
+
+  test('tangents', () => {
+    const v = new Vec3(1, 2, 3)
+    const vt1 = new Vec3()
+    const vt2 = new Vec3()
+    v.tangents(vt1, vt2)
+    expect(vt1.dot(v)).toBeCloseTo(0)
+    expect(vt2.dot(v)).toBeCloseTo(0)
+    expect(vt1.dot(vt2)).toBeCloseTo(0)
+  })
+
+  test('toString', () => {
+    const v = new Vec3(1, 2, 3)
+    expect(v.toString()).toBe('1,2,3')
+  })
+
+  test('toArray', () => {
+    const v = new Vec3(1, 2, 3)
+    const v_a = v.toArray()
+    expect(v_a[0]).toBe(1)
+    expect(v_a[1]).toBe(2)
+    expect(v_a[2]).toBe(3)
+  })
+
+  test('copy', () => {
+    const v = new Vec3(1, 2, 3)
+    const u = new Vec3()
+    u.copy(v)
+    expect(u.x).toBe(1)
+    expect(u.y).toBe(2)
+    expect(u.z).toBe(3)
+  })
+
+  test('lerp', () => {
+    const v = new Vec3(1, 2, 3)
+    const u = new Vec3(5, 6, 7)
+
+    //lerp does not implement new target vector
+    const vlerpu = new Vec3()
+    v.lerp(u, 0.5, vlerpu)
+    expect(vlerpu.x).toBeCloseTo(3)
+    expect(vlerpu.y).toBeCloseTo(4)
+    expect(vlerpu.z).toBeCloseTo(5)
+  })
+
+  test('almostEquals', () => {
+    expect(new Vec3(1, 0, 0).almostEquals(new Vec3(1, 0, 0))).toBe(true)
+    expect(new Vec3(1e-5, 1e-5, 1e-5).almostEquals(new Vec3(), 1e-6)).toBe(false)
+    expect(new Vec3(1e-7, 1e-7, 1e-7).almostEquals(new Vec3(), 1e-6)).toBe(true)
+  })
+
+  test('almostZero', () => {
+    expect(new Vec3(1, 0, 0).almostZero()).toBe(false)
+    expect(new Vec3(1e-7, 1e-7, 1e-7).almostZero(1e-6)).toBe(true)
+    expect(new Vec3(1e-5, 1e-5, 1e-5).almostZero(1e-6)).toBe(false)
+  })
+
+  test('isAntiparallelTo', () => {
+    expect(new Vec3(1, 0, 0).isAntiparallelTo(new Vec3(-1, 0, 0))).toBe(true)
+    expect(new Vec3(1, 0, 0).isAntiparallelTo(new Vec3(1, 0, 0))).toBe(false)
+  })
+
+  test('clone', () => {
+    const v = new Vec3(1, 2, 3)
+    const u = v.clone()
+    v.x = 4
+    v.y = 5
+    v.z = 6
+    expect(u.x).toBe(1)
+    expect(u.y).toBe(2)
+    expect(u.z).toBe(3)
+  })
+})

--- a/src/math/Vec3.ts
+++ b/src/math/Vec3.ts
@@ -80,11 +80,16 @@ export class Vec3 {
    * @param {Vec3} target Optional.
    * @return {Vec3}
    */
-  vadd(vector: Vec3, target = new Vec3()): Vec3 {
-    target.x = vector.x + this.x
-    target.y = vector.y + this.y
-    target.z = vector.z + this.z
-    return target
+  vadd(vector: Vec3): Vec3
+  vadd(vector: Vec3, target: Vec3): void
+  vadd(vector: Vec3, target?: Vec3): Vec3 | void {
+    if (target) {
+      target.x = vector.x + this.x
+      target.y = vector.y + this.y
+      target.z = vector.z + this.z
+    } else {
+      return new Vec3(this.x + vector.x, this.y + vector.y, this.z + vector.z)
+    }
   }
 
   /**
@@ -94,11 +99,16 @@ export class Vec3 {
    * @param {Vec3} target Optional. Target to save in.
    * @return {Vec3}
    */
-  vsub(vector: Vec3, target = new Vec3()): Vec3 {
-    target.x = this.x - vector.x
-    target.y = this.y - vector.y
-    target.z = this.z - vector.z
-    return target
+  vsub(vector: Vec3): Vec3
+  vsub(vector: Vec3, target: Vec3): void
+  vsub(vector: Vec3, target?: Vec3): Vec3 | void {
+    if (target) {
+      target.x = this.x - vector.x
+      target.y = this.y - vector.y
+      target.z = this.z - vector.z
+    } else {
+      return new Vec3(this.x - vector.x, this.y - vector.y, this.z - vector.z)
+    }
   }
 
   /**

--- a/src/math/Vec3.ts
+++ b/src/math/Vec3.ts
@@ -80,16 +80,11 @@ export class Vec3 {
    * @param {Vec3} target Optional.
    * @return {Vec3}
    */
-  vadd(vector: Vec3): Vec3
-  vadd(vector: Vec3, target: Vec3): void
-  vadd(vector: Vec3, target?: Vec3): Vec3 | void {
-    if (target) {
-      target.x = vector.x + this.x
-      target.y = vector.y + this.y
-      target.z = vector.z + this.z
-    } else {
-      return new Vec3(this.x + vector.x, this.y + vector.y, this.z + vector.z)
-    }
+  vadd(vector: Vec3, target = new Vec3()): Vec3 {
+    target.x = vector.x + this.x
+    target.y = vector.y + this.y
+    target.z = vector.z + this.z
+    return target
   }
 
   /**
@@ -99,16 +94,11 @@ export class Vec3 {
    * @param {Vec3} target Optional. Target to save in.
    * @return {Vec3}
    */
-  vsub(vector: Vec3): Vec3
-  vsub(vector: Vec3, target: Vec3): void
-  vsub(vector: Vec3, target?: Vec3): Vec3 | void {
-    if (target) {
-      target.x = this.x - vector.x
-      target.y = this.y - vector.y
-      target.z = this.z - vector.z
-    } else {
-      return new Vec3(this.x - vector.x, this.y - vector.y, this.z - vector.z)
-    }
+  vsub(vector: Vec3, target = new Vec3()): Vec3 {
+    target.x = this.x - vector.x
+    target.y = this.y - vector.y
+    target.z = this.z - vector.z
+    return target
   }
 
   /**


### PR DESCRIPTION
#49 I ported over some tests from the original cannon repository and added some more to try to give each method their own test and increase code coverage. 

While writing the tests, a few things came up:

1. Mat3.getTrace was returning void, but the doc said it should return Vec3. I made the function match the doc in commit 92083c5
2. A lot of methods allowed optional "target" objects to store the response in. Most methods did this by creating an argument with a default value of an empty object. Some functions seemed to recreate that using overloaded function definitions. I didn't think that was intentional so I made default value of empty objects consistent in commit 83050fa. 
3. Mat3.mmult and Mat3.transpose were failing the tests. If you try to multiply or transpose a matrix with itself as the argument, the data gets changed while the calculations happen creating wrong results. Commit 6ca03fb changes them to pass the tests, although this adds a little performance overhead with a Mat3.copy call each time. 

I'm hoping to write more tests for this project in the future. Is there a way that you want me to organize that? I was planning on creating pull requests as I go.

Thanks for your time.
