### PR TITLE
Fix redundant increment of world.time

### DIFF
--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -757,8 +757,7 @@ export class World extends EventTarget {
       profile.integrate = performance.now() - profilingStart
     }
 
-    // Update world time
-    this.time += dt
+    // Update step number
     this.stepnumber += 1
 
     this.dispatchEvent(World_step_postStepEvent)


### PR DESCRIPTION
As explained in #81, the time variable is increased two times when stepping the world. This is a bug that exists in cannon.js since the start.

The .time property is used internally only for the sleep mechanic, which makes the sleeping twice as faster.

Since `Body.sleepTimeLimit` is set to 1 second by default, this PR makes the sleeping behave correctly.

https://github.com/pmndrs/cannon-es/blob/cebdad108d0d97ff9b67cb65562ed784821f13ea/src/objects/Body.ts#L194

This is the `sleep.html` example:

| Before this PR | After this PR |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/7217420/110206346-61196c80-7e7d-11eb-99bf-7ae90b4d2e10.png) |  ![image](https://user-images.githubusercontent.com/7217420/110206353-6c6c9800-7e7d-11eb-9300-f567356b0000.png) |



