### PR TITLE
Use framerate independent stepping in examples

### DIFF
--- a/examples/js/PointerLockControlsCannon.js
+++ b/examples/js/PointerLockControlsCannon.js
@@ -194,6 +194,7 @@ class PointerLockControlsCannon extends THREE.EventDispatcher {
       return
     }
 
+    delta *= 1000
     delta *= 0.1
 
     this.inputVelocity.set(0, 0, 0)

--- a/examples/threejs.html
+++ b/examples/threejs.html
@@ -86,12 +86,17 @@
       function animate() {
         requestAnimationFrame(animate)
 
+        // Step the physics world
         updatePhysics()
+
+        // Copy coordinates from cannon.js to three.js
+        mesh.position.copy(body.position)
+        mesh.quaternion.copy(body.quaternion)
+
         render()
       }
 
       function updatePhysics() {
-        // Step the physics world
         const time = performance.now() / 1000
         if (!lastCallTime) {
           world.step(timeStep)
@@ -100,10 +105,6 @@
           world.step(timeStep, dt)
         }
         lastCallTime = time
-
-        // Copy coordinates from cannon.js to three.js
-        mesh.position.copy(body.position)
-        mesh.quaternion.copy(body.quaternion)
       }
 
       function render() {

--- a/examples/threejs.html
+++ b/examples/threejs.html
@@ -33,6 +33,7 @@
       let world
       let body
       const timeStep = 1 / 60
+      let lastCallTime
 
       initThree()
       initCannon()
@@ -91,7 +92,14 @@
 
       function updatePhysics() {
         // Step the physics world
-        world.step(timeStep)
+        const time = performance.now() / 1000
+        if (!lastCallTime) {
+          world.step(timeStep)
+        } else {
+          const dt = time - lastCallTime
+          world.step(timeStep, dt)
+        }
+        lastCallTime = time
 
         // Copy coordinates from cannon.js to three.js
         mesh.position.copy(body.position)

--- a/examples/threejs_cloth.html
+++ b/examples/threejs_cloth.html
@@ -28,7 +28,8 @@
        */
 
       // Specify the simulation constants
-      const dt = 1 / 60
+      const timeStep = 1 / 60
+      let lastCallTime
 
       const clothMass = 1 // 1 kg in total
       const clothSize = 1 // 1 meter
@@ -209,9 +210,21 @@
       function animate() {
         requestAnimationFrame(animate)
         controls.update()
-        world.step(dt)
+        updatePhysics()
         render()
         stats.update()
+      }
+
+      // Step the physics world
+      function updatePhysics() {
+        const time = performance.now() / 1000
+        if (!lastCallTime) {
+          world.step(timeStep)
+        } else {
+          const dt = time - lastCallTime
+          world.step(timeStep, dt)
+        }
+        lastCallTime = time
       }
 
       function render() {

--- a/examples/threejs_fps.html
+++ b/examples/threejs_fps.html
@@ -60,8 +60,8 @@
       // cannon.js variables
       let world
       let controls
-      const dt = 1 / 60
-      let lastTime = performance.now()
+      const timeStep = 1 / 60
+      let lastCallTime = performance.now()
       let sphereShape
       let sphereBody
       let physicsMaterial
@@ -325,11 +325,12 @@
       function animate() {
         requestAnimationFrame(animate)
 
-        const deltaTime = performance.now() - lastTime
-        lastTime = performance.now()
+        const time = performance.now() / 1000
+        const dt = time - lastCallTime
+        lastCallTime = time
 
         if (controls.enabled) {
-          world.step(dt)
+          world.step(timeStep, dt)
 
           // Update ball positions
           for (let i = 0; i < balls.length; i++) {
@@ -344,7 +345,7 @@
           }
         }
 
-        controls.update(deltaTime)
+        controls.update(dt)
         renderer.render(scene, camera)
         stats.update()
       }

--- a/examples/threejs_mousepick.html
+++ b/examples/threejs_mousepick.html
@@ -31,7 +31,8 @@
 
       // cannon.js variables
       let world
-      const dt = 1 / 60
+      const timeStep = 1 / 60
+      let lastCallTime
       let jointBody
       let jointConstraint
       let cubeBody
@@ -294,7 +295,8 @@
       function animate() {
         requestAnimationFrame(animate)
 
-        world.step(dt)
+        // Step the physics world
+        updatePhysics()
 
         // Sync the three.js meshes with the bodies
         for (let i = 0; i !== meshes.length; i++) {
@@ -304,6 +306,17 @@
 
         renderer.render(scene, camera)
         stats.update()
+      }
+
+      function updatePhysics() {
+        const time = performance.now() / 1000
+        if (!lastCallTime) {
+          world.step(timeStep)
+        } else {
+          const dt = time - lastCallTime
+          world.step(timeStep, dt)
+        }
+        lastCallTime = time
       }
     </script>
   </body>

--- a/examples/threejs_voxel_fps.html
+++ b/examples/threejs_voxel_fps.html
@@ -62,8 +62,8 @@
       // cannon.js variables
       let world
       let controls
-      const dt = 1 / 60
-      let lastTime = performance.now()
+      const timeStep = 1 / 60
+      let lastCallTime = performance.now() / 1000
       let sphereShape
       let sphereBody
       let physicsMaterial
@@ -299,11 +299,12 @@
       function animate() {
         requestAnimationFrame(animate)
 
-        const deltaTime = performance.now() - lastTime
-        lastTime = performance.now()
+        const time = performance.now() / 1000
+        const dt = time - lastCallTime
+        lastCallTime = time
 
         if (controls.enabled) {
-          world.step(dt)
+          world.step(timeStep, dt)
 
           // Update ball positions
           for (let i = 0; i < balls.length; i++) {
@@ -318,7 +319,7 @@
           }
         }
 
-        controls.update(deltaTime)
+        controls.update(dt)
         renderer.render(scene, camera)
         stats.update()
       }

--- a/examples/worker.html
+++ b/examples/worker.html
@@ -47,10 +47,10 @@
       }
 
       self.addEventListener('message', (event) => {
-        const { positions, quaternions, dt } = event.data
+        const { positions, quaternions, timeStep } = event.data
 
         // Step the world
-        world.step(dt)
+        world.step(timeStep)
 
         // Copy the cannon.js data into the buffers
         for (let i = 0; i < bodies.length; i++) {
@@ -84,7 +84,7 @@
       import { OrbitControls } from 'https://unpkg.com/three@0.122.0/examples/jsm/controls/OrbitControls.js'
 
       // Parameters
-      const dt = 1 / 60
+      const timeStep = 1 / 60
       const N = 40 // number of objects
 
       // Data arrays. Contains all our kinematic data we need for rendering.
@@ -118,7 +118,7 @@
         sendTime = performance.now()
         worker.postMessage(
           {
-            dt,
+            timeStep,
             positions,
             quaternions,
           },
@@ -145,9 +145,9 @@
           )
         }
 
-        // Delay the next step by the amount of dt remaining,
+        // Delay the next step by the amount of timeStep remaining,
         // otherwise run it immediatly
-        const delay = dt * 1000 - (performance.now() - sendTime)
+        const delay = timeStep * 1000 - (performance.now() - sendTime)
         setTimeout(requestDataFromWorker, Math.max(delay, 0))
       })
 

--- a/examples/worker_sharedarraybuffer.html
+++ b/examples/worker_sharedarraybuffer.html
@@ -19,7 +19,7 @@
       import * as THREE from 'https://unpkg.com/three@0.122.0/build/three.module.js'
       import { geometryToShape } from './js/three-conversion-utils.js'
 
-      const dt = 1 / 60
+      const timeStep = 1 / 60
 
       // The bodies passed down from three.js
       const bodies = []
@@ -71,12 +71,12 @@
         }
 
         // Start the loop
-        setInterval(update, dt * 1000)
+        setInterval(update, timeStep * 1000)
       })
 
       function update() {
         // Step the world
-        world.step(dt)
+        world.step(timeStep)
 
         // Copy the cannon.js data into the buffers
         for (let i = 0; i < bodies.length; i++) {


### PR DESCRIPTION
As illustrated in the new Getting started guide, we should make the framerate independent stepping the default method of stepping illustrated.