### PR TITLE
Remove @babel/plugin-proposal-class-properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.16.5",
-    "@babel/plugin-proposal-class-properties": "^7.16.5",
     "@babel/preset-env": "^7.16.5",
     "@babel/preset-typescript": "^7.16.5",
     "@rollup/plugin-babel": "^5.3.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,14 +22,6 @@ const babelOptions = {
     ],
     '@babel/preset-typescript',
   ],
-  plugins: [
-    [
-      '@babel/plugin-proposal-class-properties',
-      {
-        loose: true,
-      },
-    ],
-  ],
 }
 
 export default [


### PR DESCRIPTION
Close #89

It was messing up with the JSDoc comments.

We probably don't need babel anymore, now that create-react-app v5 is out.