### PR TITLE
Fix SparkAR usage

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -39,7 +39,7 @@ export default [
       babel(babelOptions),
       replace({
         // Use node built-in performance.now in commonjs environments
-        'globalThis.performance': `require('perf_hooks').performance`,
+        'globalThis.performance': `require('perf_hooks') && require('perf_hooks').performance`,
       }),
       filesize(),
     ],


### PR DESCRIPTION
Fixes #86

In SparkAR:

- no `window` available
- no `globalThis` available
- no `require('perf_hooks')` available

This makes performance.now() default to Date.now() in SparkAR case