### PR TITLE
Remove deprecated `body.preStep` and `body.postStep`

### DIFF
--- a/examples/callbacks.html
+++ b/examples/callbacks.html
@@ -34,7 +34,7 @@
         const planet = new CANNON.Body({ mass: 0 })
         planet.addShape(planetShape)
 
-        moon.preStep = () => {
+        world.addEventListener('preStep', () => {
           const moon_to_planet = new CANNON.Vec3()
           moon.position.negate(moon_to_planet)
 
@@ -42,7 +42,7 @@
 
           moon_to_planet.normalize()
           moon_to_planet.scale(1500 / Math.pow(distance, 2), moon.force)
-        }
+        })
 
         world.addBody(moon)
         world.addBody(planet)

--- a/src/objects/Body.ts
+++ b/src/objects/Body.ts
@@ -127,18 +127,6 @@ export class Body extends EventTarget {
    */
   world: World | null
 
-  /**
-   * Callback function that is used BEFORE stepping the system. Use it to apply forces, for example. Inside the function, "this" will refer to this Body object. Deprecated - use World events instead.
-   * @deprecated Use World events instead
-   */
-  preStep: (() => void) | null
-
-  /**
-   * Callback function that is used AFTER stepping the system. Inside the function, "this" will refer to this Body object. Deprecated - use World events instead.
-   * @deprecated Use World events instead
-   */
-  postStep: (() => void) | null
-
   vlambda: Vec3
 
   /**
@@ -444,8 +432,6 @@ export class Body extends EventTarget {
     this.id = Body.idCounter++
     this.index = -1
     this.world = null
-    this.preStep = null
-    this.postStep = null
     this.vlambda = new Vec3()
 
     this.collisionFilterGroup = typeof options.collisionFilterGroup === 'number' ? options.collisionFilterGroup : 1

--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -821,14 +821,6 @@ export class World extends EventTarget {
 
     this.dispatchEvent(World_step_preStepEvent)
 
-    // Invoke pre-step callbacks
-    for (i = 0; i !== N; i++) {
-      const bi = bodies[i]
-      if (bi.preStep) {
-        bi.preStep.call(bi)
-      }
-    }
-
     // Leap frog
     // vnew = v + h*f/m
     // xnew = x + h*vnew
@@ -854,15 +846,6 @@ export class World extends EventTarget {
     this.stepnumber += 1
 
     this.dispatchEvent(World_step_postStepEvent)
-
-    // Invoke post-step callbacks
-    for (i = 0; i !== N; i++) {
-      const bi = bodies[i]
-      const postStep = bi.postStep
-      if (postStep) {
-        postStep.call(bi)
-      }
-    }
 
     // Sleeping update
     let hasActiveBodies = true


### PR DESCRIPTION
See https://github.com/pmndrs/cannon-es/pull/116#issuecomment-1001694525

Removing some deprecated methods.
Use `world.addEventListener('preStep', () => {})` and `world.addEventListener('postStep', () => {})` instead.