### PR TITLE
add support for amd

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -44,4 +44,14 @@ export default [
       filesize(),
     ],
   },
+  {
+    input: './src/cannon-es',
+    output: {
+      file: 'dist/cannon-es.amd.js',
+      format: 'amd',
+      amd: {
+        id: 'cannon-es'
+      }
+    },
+  },
 ]


### PR DESCRIPTION
I want to use this lib at Decentraland SDK scenes instead of the cannon.js that's not longer maintained.
But in order to do that all the external libraries need to be `AMD` modules. (It's the only way that will work at Decentraland, since the build only supports amd modules) https://github.com/decentraland/js-sdk-toolchain/blob/main/packages/%40dcl/amd/src/amd.ts
Currently there are bunch of scenes created by the community that uses cannon.js such as:
https://github.com/decentraland-scenes/inflatable-punch-bag, https://github.com/decentraland-scenes/tin-can-alley, https://github.com/decentraland-scenes/cannon-example-scene, https://github.com/decentraland-scenes/cannon-car-example-scene, etc.
Will be great if we can add support for amd so we can start using it.
Thanks in advance, let me know if there's something that's not clear. :)
