### PR TITLE
Quaternion::setFromEuler documentation for TypeDoc coverage

### DIFF
--- a/src/math/Quaternion.ts
+++ b/src/math/Quaternion.ts
@@ -281,6 +281,8 @@ export class Quaternion {
   }
 
   /**
+   * Set the quaternion components given Euler angle representation.
+   *
    * @param order The order to apply angles: 'XYZ' or 'YXZ' or any other combination.
    *
    * See {@link https://www.mathworks.com/matlabcentral/fileexchange/20696-function-to-convert-between-dcm-euler-angles-quaternions-and-euler-vectors MathWorks} reference


### PR DESCRIPTION
Thank you for your work maintaining this stellar project.

`Quaternion::setFromEuler` is used in the "Getting Started" example and others, but does not appear in the documentation. This PR adds a description to make typedoc include the method in the generate docs. Please let me know if you'd like me to include the generated docs in the PR.