### PR TITLE
keep class

### DIFF
--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -25,11 +25,6 @@ body {
   display: none !important;
 }
 
-/* Hide "Class" text */
-.tsd-page-title .tsd-breadcrumb + h1 {
-  overflow: hidden;
-  text-indent: -90px;
-}
 
 /* Easier to read line-height */
 .tsd-typography p {


### PR DESCRIPTION
Hi, this removes a custom css property from doc pages. I might be misunderstanding why we need to hide this text but it's getting cut off weirdly.

Before
![image](https://user-images.githubusercontent.com/21677355/208270535-988817ae-225f-44f4-8306-dd55e7bd3977.png)


After:
![image](https://user-images.githubusercontent.com/21677355/208270541-c0ab84a9-9561-4b6c-bc4f-3aa624239a7b.png)


